### PR TITLE
消息列表某些耗时操作异步刷新

### DIFF
--- a/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/chatroomView/ChatRoomView.kt
+++ b/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/chatroomView/ChatRoomView.kt
@@ -198,7 +198,7 @@ class ChatRoomView(private val mContext: Context, mContainer: ViewGroup, private
     override fun refreshList(isForce: Boolean, data: Any?) {
         //强制刷新 直接刷新
         if (isForce) {
-            refreshInner(isForce)
+            refreshInner()
             return
         }
 
@@ -221,11 +221,11 @@ class ChatRoomView(private val mContext: Context, mContainer: ViewGroup, private
 
     }
 
-    private fun refreshInner(force: Boolean = false) {
+    private fun refreshInner() {
         mainView.post {
             val newData =
-                    if (pageType == PageType.CHAT_ROOMS) MessageFactory.getSpecChatRoom(force)
-                    else MessageFactory.getSpecOfficial(force)
+                    if (pageType == PageType.CHAT_ROOMS) MessageFactory.getSpecChatRoom()
+                    else MessageFactory.getSpecOfficial()
 
             mAdapter.data = newData
             mAdapter.notifyDataSetChanged()

--- a/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/plugins/hook/adapter/MainAdapter.kt
+++ b/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/plugins/hook/adapter/MainAdapter.kt
@@ -24,10 +24,9 @@ import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge.hookAllConstructors
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.XposedHelpers.findAndHookMethod
-import net.dongliu.apk.parser.Main
-import java.lang.Exception
-import java.lang.RuntimeException
 import java.lang.reflect.ParameterizedType
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 @SuppressLint("StaticFieldLeak")
 /**
@@ -41,6 +40,13 @@ object MainAdapter {
     var firstChatRoomPosition = -1
     var firstOfficialPosition = -1
 
+    // 可能同时刷新 2 个，故开2个线程
+    val asyncExecutor: Executor = Executors.newFixedThreadPool(2)
+
+    // 如果用户接受在主线程刷消息，那就在主线程
+    val mainThreadExecutor: Executor = Executor {
+        it.run()
+    }
 
     fun isOriginAdapterIsInitialized() = MainAdapter::originAdapter.isInitialized
 
@@ -102,16 +108,18 @@ object MainAdapter {
 
                         LogUtils.log("MMBaseAdapter_getView, afterHookedMethod, index = $position, view = $view")
 
-                        if (position == firstChatRoomPosition || position == firstOfficialPosition) {
+                        if (view == null) {
+                            return
+                        }
 
-                            if (view != null) {
-                                refreshEntryView(view, position, param)
-                            }
+                        if (position == firstChatRoomPosition) {
+                            refreshChatEntryView(view, position)
+                        } else if (position == firstOfficialPosition) {
+                            refreshOfficialView(view, position)
                         }
                     }
 
-
-                    private fun refreshEntryView(view: View?, position: Int, param: MethodHookParam) {
+                    private fun refreshChatEntryView(view: View?, position: Int) {
                         LogUtils.log("MessageHooker2.6,position = $position, position = $position, " +
                                 "firstChatRoomPosition = $firstChatRoomPosition ,firstOfficialPosition = $firstOfficialPosition \n")
 
@@ -131,12 +139,29 @@ object MainAdapter {
                         val content = ((textContainer.getChildAt(1) as ViewGroup).getChildAt(0) as ViewGroup).getChildAt(1)
                         val muteImage = ((textContainer.getChildAt(1) as ViewGroup).getChildAt(1) as ViewGroup).getChildAt(1)
 
+                        unReadCount.visibility = View.GONE
+                        unMuteReadIndicators.visibility = View.GONE
+                        XposedHelpers.callMethod(content, "setDrawLeftDrawable", false)
 
-                        if (position == firstChatRoomPosition) {
-                            unReadCount.visibility = View.GONE
-                            unMuteReadIndicators.visibility = View.GONE
-                            XposedHelpers.callMethod(content, "setDrawLeftDrawable", false)
+                        setTextForNoMeasuredTextView(nickname, "群聊消息" + (if (MainAdapterLongClick.chatRoomStickyValue > 0) " - 置顶" else ""))
+                        avatar.setImageDrawable(DrawableMaker.handleAvatarDrawable(avatar.context, PageType.CHAT_ROOMS))
+                        sendStatus.visibility = View.GONE
+                        muteImage.visibility = View.GONE
 
+                        if (MainAdapterLongClick.chatRoomStickyValue > 0) {
+                            itemView.background = ColorDrawable(Color.rgb(237, 237, 237))
+                            // itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemHighLightSelectorBackGroundInt)
+                        } else {
+                            itemView.background = ColorDrawable(Color.rgb(255, 255, 255))
+                            //  itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemSelectorBackGroundInt)
+                        }
+
+                        // TODO: 添加配置，让用户可以选择是否异步刷新
+                        val async = true
+                        val executor: Executor = if (async) asyncExecutor else mainThreadExecutor
+
+                        // 接下来的操作可能耗时，异步刷新
+                        executor.execute {
                             val allChatRoom = MessageFactory.getSpecChatRoom()
                             val unReadCountItem = MessageFactory.getUnReadCountItem(allChatRoom)
                             val totalUnReadCount = MessageFactory.getUnReadCount(allChatRoom)
@@ -145,91 +170,98 @@ object MainAdapter {
 
                             val chatInfoModel = allChatRoom.sortedBy { -it.field_conversationTime }.first()
 
-                            setTextForNoMeasuredTextView(nickname, "群聊消息" + (if (MainAdapterLongClick.chatRoomStickyValue > 0) " - 置顶" else ""))
-                            setTextForNoMeasuredTextView(time, chatInfoModel.conversationTime)
-                            avatar.setImageDrawable(DrawableMaker.handleAvatarDrawable(avatar.context, PageType.CHAT_ROOMS))
+                            view.post {
+                                setTextForNoMeasuredTextView(time, chatInfoModel.conversationTime)
 
-                            sendStatus.visibility = View.GONE
-                            muteImage.visibility = View.GONE
+                                if (unReadCountItem > 0) {
 
-                            if (unReadCountItem > 0) {
+                                    val spannableStringBuilder = SpannableStringBuilder()
 
-                                val spannableStringBuilder = SpannableStringBuilder()
+                                    var firstLength = 0
+                                    if (unMuteUnReadCount > 0) {
+                                        spannableStringBuilder.append("[${unMuteUnReadCount}条] ")
+                                        firstLength = spannableStringBuilder.length
+                                        spannableStringBuilder.setSpan(ForegroundColorSpan(0xFFF44336.toInt()), 0, firstLength, SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE)
+                                    }
+                                    spannableStringBuilder.append("[ ${unReadCountItem} 个群聊收到 ${totalUnReadCount} 条新消息]")
+                                    spannableStringBuilder.setSpan(ForegroundColorSpan(0xFFF57C00.toInt()), firstLength, spannableStringBuilder.length, SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-                                var firstLength = 0
-                                if (unMuteUnReadCount > 0) {
-                                    spannableStringBuilder.append("[${unMuteUnReadCount}条] ")
-                                    firstLength = spannableStringBuilder.length
-                                    spannableStringBuilder.setSpan(ForegroundColorSpan(0xFFF44336.toInt()), 0, firstLength, SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE)
+                                    setTextForNoMeasuredTextView(content, spannableStringBuilder)
+                                    unMuteReadIndicators.visibility = View.VISIBLE
+                                } else {
+                                    setTextColorForNoMeasuredTextView(content, 0xFF999999.toInt())
+                                    setTextForNoMeasuredTextView(content, "${chatInfoModel.nickname}：${chatInfoModel.content}")
+                                    unMuteReadIndicators.visibility = View.GONE
                                 }
-                                spannableStringBuilder.append("[ ${unReadCountItem} 个群聊收到 ${totalUnReadCount} 条新消息]")
-                                spannableStringBuilder.setSpan(ForegroundColorSpan(0xFFF57C00.toInt()), firstLength, spannableStringBuilder.length, SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE)
-
-                                setTextForNoMeasuredTextView(content, spannableStringBuilder)
-                                unMuteReadIndicators.visibility = View.VISIBLE
-                            } else {
-                                setTextColorForNoMeasuredTextView(content, 0xFF999999.toInt())
-                                setTextForNoMeasuredTextView(content, "${chatInfoModel.nickname}：${chatInfoModel.content}")
-                                unMuteReadIndicators.visibility = View.GONE
                             }
-
-
-                            if (MainAdapterLongClick.chatRoomStickyValue > 0) {
-                                itemView.background = ColorDrawable(Color.rgb(237, 237, 237))
-                                // itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemHighLightSelectorBackGroundInt)
-                            } else {
-                                itemView.background = ColorDrawable(Color.rgb(255, 255, 255))
-                                //  itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemSelectorBackGroundInt)
-                            }
-
-                            param.result = view
-
                         }
-                        if (position == firstOfficialPosition) {
-                            unReadCount.visibility = View.GONE
-                            unMuteReadIndicators.visibility = View.GONE
-                            XposedHelpers.callMethod(content, "setDrawLeftDrawable", false)
+                    }
 
+                    private fun refreshOfficialView(view: View?, position: Int) {
+                        LogUtils.log("MessageHooker2.6,position = $position, position = $position, " +
+                                "firstChatRoomPosition = $firstChatRoomPosition ,firstOfficialPosition = $firstOfficialPosition \n")
 
+                        val itemView = view as ViewGroup
+
+                        val avatarContainer = itemView.getChildAt(0) as ViewGroup
+                        val textContainer = itemView.getChildAt(1) as ViewGroup
+
+                        val avatar = avatarContainer.getChildAt(0) as ImageView
+                        val unReadCount = avatarContainer.getChildAt(1) as TextView
+                        val unMuteReadIndicators = avatarContainer.getChildAt(2) as ImageView
+
+                        val nickname = ((textContainer.getChildAt(0) as ViewGroup).getChildAt(0) as ViewGroup).getChildAt(0)
+                        val time = (textContainer.getChildAt(0) as ViewGroup).getChildAt(1)
+
+                        val sendStatus = ((textContainer.getChildAt(1) as ViewGroup).getChildAt(0) as ViewGroup).getChildAt(0)
+                        val content = ((textContainer.getChildAt(1) as ViewGroup).getChildAt(0) as ViewGroup).getChildAt(1)
+                        val muteImage = ((textContainer.getChildAt(1) as ViewGroup).getChildAt(1) as ViewGroup).getChildAt(1)
+
+                        unReadCount.visibility = View.GONE
+                        unMuteReadIndicators.visibility = View.GONE
+                        XposedHelpers.callMethod(content, "setDrawLeftDrawable", false)
+
+                        sendStatus.visibility = View.GONE
+                        muteImage.visibility = View.GONE
+
+                        setTextForNoMeasuredTextView(nickname, "服务号消息" + (if (MainAdapterLongClick.officialStickyValue > 0) " - 置顶" else ""))
+                        if (MainAdapterLongClick.officialStickyValue > 0) {
+                            itemView.background = ColorDrawable(Color.rgb(237, 237, 237))
+                            //   itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemHighLightSelectorBackGroundInt)
+                        } else {
+                            itemView.background = ColorDrawable(Color.rgb(255, 255, 255))
+                            // itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemSelectorBackGroundInt)
+                        }
+
+                        val async = true
+                        val executor: Executor = if (async) asyncExecutor else mainThreadExecutor
+                        executor.execute {
                             val allOfficial = MessageFactory.getSpecOfficial()
                             val unReadCountItem = MessageFactory.getUnReadCountItem(allOfficial)
                             val totalUnReadCount = MessageFactory.getUnReadCount(allOfficial)
 
                             LogUtils.log("getUnReadCountItemChatRoom " + allOfficial.joinToString { "unReadCount = ${it.unReadCount}" })
 
-                            sendStatus.visibility = View.GONE
-                            muteImage.visibility = View.GONE
-
                             val chatInfoModel = allOfficial.sortedBy { -it.field_conversationTime }.first()
 
-                            setTextForNoMeasuredTextView(nickname, "服务号消息" + (if (MainAdapterLongClick.officialStickyValue > 0) " - 置顶" else ""))
-                            setTextForNoMeasuredTextView(time, chatInfoModel.conversationTime)
-                            avatar.setImageDrawable(DrawableMaker.handleAvatarDrawable(avatar.context, PageType.OFFICIAL))
+                            view.post {
+                                setTextForNoMeasuredTextView(time, chatInfoModel.conversationTime)
+                                avatar.setImageDrawable(DrawableMaker.handleAvatarDrawable(avatar.context, PageType.OFFICIAL))
 
-                            if (unReadCountItem > 0) {
-                                setTextForNoMeasuredTextView(content, "[ ${unReadCountItem} 个服务号收到 ${totalUnReadCount} 条新消息]")
-                                setTextColorForNoMeasuredTextView(content, 0xFFF57C00.toInt())
-                                unMuteReadIndicators.visibility = View.VISIBLE
-                            } else {
-                                setTextForNoMeasuredTextView(content, "${chatInfoModel.nickname}：${chatInfoModel.content}")
-                                setTextColorForNoMeasuredTextView(content, 0xFF999999.toInt())
-                                unMuteReadIndicators.visibility = View.GONE
+                                if (unReadCountItem > 0) {
+                                    setTextForNoMeasuredTextView(content, "[ ${unReadCountItem} 个服务号收到 ${totalUnReadCount} 条新消息]")
+                                    setTextColorForNoMeasuredTextView(content, 0xFFF57C00.toInt())
+                                    unMuteReadIndicators.visibility = View.VISIBLE
+                                } else {
+                                    setTextForNoMeasuredTextView(content, "${chatInfoModel.nickname}：${chatInfoModel.content}")
+                                    setTextColorForNoMeasuredTextView(content, 0xFF999999.toInt())
+                                    unMuteReadIndicators.visibility = View.GONE
+                                }
                             }
-
-                            if (MainAdapterLongClick.officialStickyValue > 0) {
-                                itemView.background = ColorDrawable(Color.rgb(237, 237, 237))
-                                //   itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemHighLightSelectorBackGroundInt)
-                            } else {
-                                itemView.background = ColorDrawable(Color.rgb(255, 255, 255))
-                                // itemView.setBackgroundResource(WXObject.Adapter.F.ConversationItemSelectorBackGroundInt)
-                            }
-
-                            param.result = view
                         }
-
                     }
-                })
 
+                })
 
         /**
          * 修改 getObject 的数据下标
@@ -272,7 +304,7 @@ object MainAdapter {
                 LogUtils.log("MessageHooker 2019-04-02 09:18:31, size = ${originAdapter.count}, firstChatRoomPosition = $firstChatRoomPosition, firstOfficialPosition = $firstOfficialPosition")
 
                 val newIndex =
-                //如果没有群助手和公众号
+                        //如果没有群助手和公众号
                         if (min == -1 && max == -1) {
                             index
                         }

--- a/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/plugins/hook/message/MessageFactory.kt
+++ b/Wechat_chatroom_helper_android/app/src/main/kotlin/com/zdy/project/wechat_chatroom_helper/wechat/plugins/hook/message/MessageFactory.kt
@@ -29,8 +29,6 @@ object MessageFactory {
             "atCount, unReadMuteCount, UnReadInvite from rconversation, rcontact " +
             "where rconversation.username = rcontact.username and rconversation.username = '$field_username'"
 
-    private val specChatRoom: ArrayList<ChatInfoModel> = ArrayList()
-    private val specOfficial: ArrayList<ChatInfoModel> = ArrayList()
 
     @JvmStatic
     fun getDataBaseFactory(any: Any) = XposedHelpers.findField(any::class.java, "mCursorFactory").apply { isAccessible = true }.get(any)
@@ -63,35 +61,21 @@ object MessageFactory {
         return list
     }
 
-    fun getSpecChatRoom(force: Boolean = false): ArrayList<ChatInfoModel> {
-        if (!force && specChatRoom.isNotEmpty()) {
-            return specChatRoom
-        }
+    fun getSpecChatRoom(): ArrayList<ChatInfoModel> {
         val list = getAllChatRoom()
         val chatroomList = AppSaveInfo.getWhiteList(AppSaveInfo.WHITE_LIST_CHAT_ROOM)
         val data = ArrayList(list.filterNot { chatroomList.contains(it.field_username) })
 
         LogUtils.log("getSpecChatRoom, list = ${list.joinToString { it.toString() }}, data = ${data.joinToString { it.toString() }}")
-
-        specChatRoom.clear()
-        specChatRoom.addAll(data)
-
         return data
     }
 
-    fun getSpecOfficial(force: Boolean = false): ArrayList<ChatInfoModel> {
-        if (!force && specOfficial.isNotEmpty()) {
-            return specOfficial
-        }
+    fun getSpecOfficial(): ArrayList<ChatInfoModel> {
         val list = getAllOfficial()
         val officialList = AppSaveInfo.getWhiteList(AppSaveInfo.WHITE_LIST_OFFICIAL)
         val data = ArrayList(list.filterNot { officialList.contains(it.field_username) })
 
         LogUtils.log("getSpecOfficial, list = ${list.joinToString { it.toString() }}, data = ${data.joinToString { it.toString() }}")
-
-        specOfficial.clear()
-        specOfficial.addAll(data)
-
         return data
     }
 


### PR DESCRIPTION
之前的那个用缓存的方式有硬伤，消息列表更新不了，故revert了。

新的方式把耗时操作放在线程里面做，做完之后异步刷新view。同时可以增加配置，让用户选择是同步刷新还是异步刷新。(配置项界面没有做。。)